### PR TITLE
[AIP-264] mmcai-teardown.sh: remove node labels on resource teardown

### DIFF
--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -256,9 +256,9 @@ if $remove_cluster_resources; then
     fi
 
     # Get all mmc.ai labels attached to nodes
-    mmcai_labels=$(kubectl get nodes -A -o json | jq -r '.items[].metadata.labels' | sed 's/\("\|,\)//g' | awk -F':' '{print $1}' | grep mmc.ai)
+    mmcai_labels=$(kubectl describe nodes -A | sed 's/=/ /g' | awk '{print $1}' | grep mmc.ai)
 
-    for label in $mmcai_labels; do
+    for label in ${mmcai_labels[@]}; do
         kubectl label nodes --all ${label}-
     done
 

--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -255,10 +255,8 @@ if $remove_cluster_resources; then
         done
     fi
 
-    mmcai_labels='
-        mmc.ai/department
-        mmc.ai/nodegroup
-    '
+    # Get all mmc.ai labels attached to nodes
+    mmcai_labels=$(kubectl get nodes -A -o json | jq -r '.items[].metadata.labels' | sed 's/\("\|,\)//g' | awk -F':' '{print $1}' | grep mmc.ai)
 
     for label in $mmcai_labels; do
         kubectl label nodes --all ${label}-

--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -255,6 +255,15 @@ if $remove_cluster_resources; then
         done
     fi
 
+    mmcai_labels='
+        mmc.ai/department
+        mmc.ai/nodegroup
+    '
+
+    for label in $mmcai_labels; do
+        kubectl label nodes --all ${label}-
+    done
+
     wait $cluster_resource_crds_removed
 
     for cluster_resource_crd in $cluster_resource_crds; do


### PR DESCRIPTION
To address https://memverge.atlassian.net/browse/AIP-264, get all mmc.ai labels from nodes via regexes, and then remove them.