### PR TITLE
[AIP-241] mmcai-setup.sh: install internal chart if credentials allow

### DIFF
--- a/kubeflow-teardown.sh
+++ b/kubeflow-teardown.sh
@@ -6,6 +6,8 @@ TEMP_DIR=$(mktemp -d)
 
 cleanup() {
     rm -rf $TEMP_DIR
+    sudo rm -rf /usr/local/bin/kustomize
+    trap - EXIT
     exit
 }
 

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -2,6 +2,20 @@
 
 source logging.sh
 
+## install jq for later parsing
+
+cleanup() {
+    sudo rm -rf /usr/local/bin/jq
+    trap - EXIT
+    exit
+}
+
+trap cleanup EXIT
+
+wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+chmod +x jq
+sudo cp jq /usr/local/bin/
+
 ## welcome message
 
 div

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -27,11 +27,65 @@ chmod +x mysql-pre-setup.sh
 ./mysql-pre-setup.sh
 
 div
-log_good "Creating namespaces if needed..."
-div
+log_good "Creating namespaces, and applying image pull secrets if present..."
+
+install_internal=false
+install_repository="oci://ghcr.io/memverge/charts"
+
+# Log into helm using the credentials from the image pull secret.
+function helm_login() {
+    # Extract creds
+    secret_json=$(
+        kubectl get secret memverge-dockerconfig -n mmcai-system --output="jsonpath={.data.\.dockerconfigjson}" |
+        base64 --decode
+    )
+    secret_user=$(echo ${secret_json} | jq -r '.auths."ghcr.io/memverge".username')
+    secret_token=$(echo ${secret_json} | jq -r '.auths."ghcr.io/memverge".password')
+
+    # Attempt login
+    if helm login ghcr.io/memverge -u $secret_user -p $secret_token; then
+        div
+        log_good "Helm login was successful."
+    else
+        div
+        log_bad "Helm login was unsuccessful. Please provide an mmcai-ghcr-secret.yaml that allows helm login."
+        div
+        log "Report:"
+        cat mmcai-ghcr-secret.yaml
+        div
+        exit 1
+    fi
+}
+
+function determine_install_type() {
+    # mmcai-ghcr-secret may allow user to pull internal charts.
+    # If so, ask user if they want to pull internal or external.
+    helm pull oci://ghcr.io/memverge/charts/internal/mmcai-cluster --devel
+    if ls mmcai-cluster* > /dev/null 2>&1; then
+        rm mmcai-cluster*
+
+        div
+        log_good "Your mmcai-ghcr-secret.yaml allows you to pull internal images."
+        
+        read -p "Would you like to install internal builds on your cluster? [Y/n]:" install_internal
+        case $install_internal in
+            [Nn]* ) install_internal=false;;
+            * ) install_internal=true;;
+        esac
+    fi
+
+    if $install_internal; then
+        install_repository="oci://ghcr.io/memverge/charts/internal"
+    fi
+
+    div
+    log "Based on mmcai-ghcr-secret.yaml credentials, will install from $install_repository"
+}
 
 if [[ -f "mmcai-ghcr-secret.yaml" ]]; then
     kubectl apply -f mmcai-ghcr-secret.yaml
+    helm_login
+    determine_install_type
 else
     kubectl create ns $NAMESPACE
     kubectl create ns mmcloud-operator-system
@@ -42,7 +96,7 @@ fi
 kubectl get namespace monitoring &>/dev/null || kubectl create namespace monitoring
 
 div
-log_good "Creating secrets if needed..."
+log_good "Creating mysql secret..."
 div
 
 ## Create MySQL secret
@@ -55,12 +109,12 @@ kubectl -n $NAMESPACE create secret generic mmai-mysql-secret \
     --from-literal=mysql-replication-password=$MYSQL_ROOT_PASSWORD
 
 div
-log_good "Beginning installation..."
+log_good "Installing charts..."
 div
 
 ## install mmc.ai system
-helm install --debug -n $NAMESPACE mmcai-cluster oci://ghcr.io/memverge/charts/mmcai-cluster \
+helm install --debug -n $NAMESPACE mmcai-cluster ${install_repository}/mmcai-cluster \
     --set billing.database.nodeHostname=$mysql_node_hostname
 
 ## install mmc.ai management
-helm install --debug -n $NAMESPACE mmcai-manager oci://ghcr.io/memverge/charts/mmcai-manager
+helm install --debug -n $NAMESPACE mmcai-manager ${install_repository}/mmcai-manager

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -132,13 +132,22 @@ function helm_login() {
 }
 
 function helm_poke() {
-    attempts=3
+    attempts=1
+    limit=5
+
+    log "Will attempt to pull $1 $attempt times..."
     until helm pull --devel $1 2>&1 > /dev/null; do
-        if [ $attempts -eq 0 ]; then
+        log "Attempt $attempts failed."
+    
+        attempts=$((attempts + 1))
+        if [ $attempts -gt $limit ]; then
             return 1
         fi
-        attempts=$((attempts - 1))
+    
+        sleep 1
     done
+
+    log "Attempt $attempts succeeded."
     return 0
 }
 

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -45,13 +45,11 @@ function get_opts() {
             MMCAI_GHCR_SECRET="$OPTARG"
             ;;
         \?)
-            div
             log_bad "Invalid option: -$OPTARG" >&2
             usage
             exit 1
             ;;
         :)
-            div
             log_bad "Option -$OPTARG requires an argument." >&2
             usage
             exit 1
@@ -71,14 +69,12 @@ function autofind_secret() {
     else
         # No local secret and no OPTARG; exit
         if [ -z "$MMCAI_GHCR_SECRET" ]; then
-            div
             log_bad "Please provide a path to ${SECRET_YAML}."
             usage
             exit 1
         fi
     fi
 
-    div
     log_good "Found image pull secret ${MMCAI_GHCR_SECRET}."
     log_good "Do you want to use these credentials to set up MMC.AI? [Y/n]"
     read -p "" $continue
@@ -96,15 +92,13 @@ function autofind_secret() {
 
 
 function setup_mysql_directories() {
-    div
     log_good "Please provide information for billing database:"
     read -p "MySQL database node hostname: " mysql_node_hostname
     read -sp "MySQL root password: " mysql_root_password
     echo ""
 
-    div
     log_good "Creating directories for billing database:"
-    div
+    div 
 
     wget -O mysql-pre-setup.sh https://raw.githubusercontent.com/MemVerge/mmc.ai-setup/main/mysql-pre-setup.sh
     chmod +x mysql-pre-setup.sh
@@ -129,15 +123,11 @@ function helm_login() {
 
     # Attempt login
     if echo $secret_token | helm registry login ghcr.io/memverge -u $secret_user --password-stdin; then
-        div
         log_good "Helm login was successful."
     else
-        div
         log_bad "Helm login was unsuccessful. Please provide an ${SECRET_YAML} that allows helm login."
-        div
         log "Report:"
         cat ${SECRET_YAML}
-        div
         exit 1
     fi
 }
@@ -192,7 +182,6 @@ function determine_install_type() {
     # If so, ask user if they want to pull internal or external.
     if helm_poke oci://ghcr.io/memverge/charts/internal/mmcai-manager; then
         rm mmcai-manager*
-        div
         log_good "Your ${SECRET_YAML} allows you to pull internal images."
         log_good "Would you like to install internal builds on your cluster? [Y/n]:"
         
@@ -203,10 +192,8 @@ function determine_install_type() {
         esac
     elif helm_poke oci://ghcr.io/memverge/charts/mmcai-manager; then
         rm mmcai-manager*
-        div
         log_good "Your ${SECRET_YAML} allows you to pull customer images."
     else
-        div
         log_bad "Your ${SECRET_YAML} does not allow you to pull images. Please contact MemVerge customer support."
         exit 1
     fi
@@ -218,12 +205,10 @@ function determine_install_type() {
         install_flags="--debug --devel"
     fi
 
-    div
     log "Based on ${SECRET_YAML} credentials, will install from $install_repository."
 }
 
 function setup_mmcai_secret() {
-    div
     log_good "Creating namespaces, and applying image pull secrets if present..."
 
     if [[ -f "${MMCAI_GHCR_SECRET}" ]]; then
@@ -240,9 +225,7 @@ function setup_mmcai_secret() {
 
 
 function setup_mysql_secret() {
-    div
     log_good "Creating mysql secret..."
-    div
 
     kubectl -n $NAMESPACE get secret mmai-mysql-secret &>/dev/null || \
     # While we only need mysql-root-password, all of these keys are
@@ -255,26 +238,36 @@ function setup_mysql_secret() {
 
 
 function do_install() {
-    div
     log_good "Installing charts..."
-    div
 
     helm_install
 }
 
 
 div
+
 log "Welcome to MMC.AI setup!"
+
 div
 
 get_opts ${@}
 
+div
+
 autofind_secret
+
+div
 
 setup_mysql_directories
 
+div
+
 setup_mmcai_secret
 
+div
+
 setup_mysql_secret
+
+div
 
 do_install

--- a/mmcai-setup.sh
+++ b/mmcai-setup.sh
@@ -161,12 +161,12 @@ function helm_install() {
 
     if ! helm_poke ${install_repository}/mmcai-manager; then
         log_bad "Could not pull mmcai-manager! Try this script again, and if the issue persists, contact support@memverge.com."
-        rm -rf mmcai-cluster*
+        rm -rf mmcai-cluster*.tgz
         exit 1
     fi
 
-    mmcai_cluster_tgz=$(ls mmcai-cluster* | head -n 1)
-    mmcai_manager_tgz=$(ls mmcai-manager* | head -n 1)
+    mmcai_cluster_tgz=$(ls mmcai-cluster*.tgz | head -n 1)
+    mmcai_manager_tgz=$(ls mmcai-manager*.tgz | head -n 1)
 
     helm install $install_flags -n $NAMESPACE mmcai-cluster $mmcai_cluster_tgz \
         --set billing.database.nodeHostname=$mysql_node_hostname


### PR DESCRIPTION
I know we'll be replacing mmcai-setup.sh with the new version soon, but I wanted to start implementing this check + credential-pulling scheme. Will port it over to the new version, maybe as I test it.