### PR TITLE
Improve teardown error handling

### DIFF
--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -293,7 +293,9 @@ if $remove_cluster_resources; then
         kubectl label nodes --all ${label}-
     done
 
-    wait $cluster_resource_crds_removed
+    if ! wait $cluster_resource_crds_removed; then
+        log_bad "Cluster resources may not have been removed successfully."
+    fi
 
     for cluster_resource_crd in $cluster_resource_crds; do
         if ! get_crd_output=$(kubectl get crd $cluster_resource_crd --ignore-not-found); then
@@ -351,7 +353,9 @@ if $remove_nvidia_gpu_operator; then
     if cluster_policies=$(kubectl get clusterpolicies -o custom-columns=:.metadata.name) \
     && ! [ -z "$cluster_policies" ]
     then
-        kubectl delete clusterpolicies $cluster_policies --ignore-not-found
+        if ! kubectl delete clusterpolicies $cluster_policies --ignore-not-found; then
+            log_bad "NVIDIA cluster policies may not have been removed successfully."
+        fi
     fi
 
     helm uninstall --debug -n gpu-operator nvidia-gpu-operator --ignore-not-found

--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+set -uo pipefail
+
+ignore_errors=false
+
+while getopts "i" option; do
+    case $option in
+        i ) ignore_errors=true;;
+        * ) echo "Invalid option. Use -i to ignore errors."
+    esac
+done
+
+if ! $ignore_errors; then
+    set -e
+fi
+
 # set -euo pipefail
 
 source logging.sh
@@ -235,20 +250,38 @@ if $remove_cluster_resources; then
         departments.mmc.ai
     '
 
+    log "Requesting CRD deletion..."
     kubectl delete crd $cluster_resource_crds --ignore-not-found &
     cluster_resource_crds_removed=$!
 
     if $force_if_remove_cluster_resources; then
+        log "Force removing cluster resources..."
         for cluster_resource_crd in $cluster_resource_crds; do
-            until [ -z "$(kubectl get crd $cluster_resource_crd --ignore-not-found)" ]; do
+            log "Removing $cluster_resource_crds resources..."
+
+            if ! get_crd_output=$(kubectl get crd $cluster_resource_crd --ignore-not-found); then
+                error_or_found=true
+            elif [ -z "$get_crd_output" ]; then
+                error_or_found=false
+            else
+                error_or_found=true
+            fi
+
+            while $error_or_found; do
                 namespaces=$(kubectl get namespaces -o custom-columns=:.metadata.name)
                 for namespace in $namespaces; do
-                    if [ -z "$(kubectl get crd $cluster_resource_crd --ignore-not-found)" ]; then
-                        break
-                    fi
-                    resources=$(kubectl get -n $namespace $cluster_resource_crd -o custom-columns=:.metadata.name)
-                    if ! [ -z "$resources" ]; then
-                        kubectl patch $cluster_resource_crd -n $namespace $resources --type json --patch='[{ "op": "remove", "path": "/metadata/finalizers" }]'
+                    if ! get_crd_output=$(kubectl get crd $cluster_resource_crd --ignore-not-found); then
+                        error_or_found=true
+                    elif [ -z "$get_crd_output" ]; then
+                        error_or_found=false
+                    else
+                        error_or_found=true
+                        # This should work for cluster-wide resources.
+                        if ! resources=$(kubectl get -n $namespace $cluster_resource_crd -o custom-columns=:.metadata.name); then
+                            continue
+                        elif ! [ -z "$resources" ]; then
+                            kubectl patch $cluster_resource_crd -n $namespace $resources --type json --patch='[{ "op": "remove", "path": "/metadata/finalizers" }]' || true
+                        fi
                     fi
                 done
             done
@@ -265,7 +298,9 @@ if $remove_cluster_resources; then
     wait $cluster_resource_crds_removed
 
     for cluster_resource_crd in $cluster_resource_crds; do
-        if ! [ -z "$(kubectl get crd $cluster_resource_crd --ignore-not-found)" ]; then
+        if ! get_crd_output=$(kubectl get crd $cluster_resource_crd --ignore-not-found); then
+            log_bad "CRD $cluster_resource_crd may not have been removed successfully."
+        elif ! [ -z "$get_crd_output" ]; then
             log_bad "CRD $cluster_resource_crd was not removed successfully."
         fi
     done
@@ -315,10 +350,9 @@ if $remove_nvidia_gpu_operator; then
     # NVIDIA GPU Operator Helm chart does not create an instance of this CRD so the CRD can be deleted first.
     kubectl delete crd nvidiadrivers.nvidia.com --ignore-not-found
 
-    if kubectl get crd clusterpolicies.nvidia.com; then
-        cluster_policies=$(kubectl get clusterpolicies -o custom-columns=:.metadata.name)
-    fi
-    if ! [ -z "$cluster_policies" ]; then
+    if cluster_policies=$(kubectl get clusterpolicies -o custom-columns=:.metadata.name) \
+    && ! [ -z "$cluster_policies" ]
+    then
         kubectl delete clusterpolicies $cluster_policies --ignore-not-found
     fi
 

--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -15,8 +15,6 @@ if ! $ignore_errors; then
     set -e
 fi
 
-# set -euo pipefail
-
 source logging.sh
 
 remove_mmcai_cluster=false

--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -255,7 +255,7 @@ if $remove_cluster_resources; then
     if $force_if_remove_cluster_resources; then
         log "Force removing cluster resources..."
         for cluster_resource_crd in $cluster_resource_crds; do
-            log "Removing $cluster_resource_crds resources..."
+            log "Removing $cluster_resource_crd resources..."
 
             if ! get_crd_output=$(kubectl get crd $cluster_resource_crd --ignore-not-found); then
                 error_or_found=true

--- a/mmcai-teardown.sh
+++ b/mmcai-teardown.sh
@@ -280,7 +280,7 @@ if $remove_cluster_resources; then
                         if ! resources=$(kubectl get -n $namespace $cluster_resource_crd -o custom-columns=:.metadata.name); then
                             log_bad "Unhandled error getting $cluster_resource_crd resources in namespace $namespace. May loop infinitely."
                             sleep 1
-                        elif ! [[ -z "$resources" ]]; then
+                        elif [[ -n "$resources" ]]; then
                             if ! kubectl patch $cluster_resource_crd -n $namespace $resources --type json --patch='[{ "op": "remove", "path": "/metadata/finalizers" }]'; then
                                 log_bad "Unhandled error patching $cluster_resource_crd resources in namespace $namespace. May loop infinitely."
                                 sleep 1
@@ -312,7 +312,7 @@ if $remove_cluster_resources; then
     for cluster_resource_crd in $cluster_resource_crds; do
         if ! get_crd_output=$(kubectl get crd $cluster_resource_crd --ignore-not-found); then
             log_bad "CRD $cluster_resource_crd may not have been removed successfully."
-        elif ! [ -z "$get_crd_output" ]; then
+        elif [[ -n "$get_crd_output" ]]; then
             log_bad "CRD $cluster_resource_crd was not removed successfully."
         fi
     done
@@ -363,7 +363,7 @@ if $remove_nvidia_gpu_operator; then
     kubectl delete crd nvidiadrivers.nvidia.com --ignore-not-found
 
     if cluster_policies=$(kubectl get clusterpolicies -o custom-columns=:.metadata.name) \
-    && ! [ -z "$cluster_policies" ]
+    && [[ -n "$cluster_policies" ]]
     then
         if ! kubectl delete clusterpolicies $cluster_policies --ignore-not-found; then
             log_bad "NVIDIA cluster policies may not have been removed successfully."


### PR DESCRIPTION
This should allow using set -e by default again.
Adds a little more logging.
Logs when some resources may not have been/are not removed successfully instead of exiting (if set -e).

Fixes:
- race conditions where a CRD `TYPE` is removed after checking for existence of `TYPE`, causing kubectl `OPERATION` `TYPE` `INSTANCE` to fail even with --ignore-not-found