### PR TITLE
More reliable Kubeflow teardown

### DIFF
--- a/kubeflow-teardown.sh
+++ b/kubeflow-teardown.sh
@@ -30,6 +30,7 @@ rm -rf install_kustomize.sh
 KUBEFLOW_VERSION='v1.9.0'
 KUBEFLOW_ISTIO_VERSION='1.22'
 KUBEFLOW_MANIFEST='kubeflow-manifest.yaml'
+KUBEFLOW_DOCUMENTS_DIRECTORY='kubeflow-documents'
 
 log "Cloning Kubeflow manifests..."
 git clone https://github.com/kubeflow/manifests.git $TEMP_DIR/kubeflow --branch $KUBEFLOW_VERSION
@@ -46,11 +47,36 @@ sed -i 's:VWA_APP_SECURE_COOKIES=true:VWA_APP_SECURE_COOKIES=false:' "$TEMP_DIR/
 sed -i 's:TWA_APP_SECURE_COOKIES=true:TWA_APP_SECURE_COOKIES=false:' "$TEMP_DIR/kubeflow/apps/tensorboard/tensorboards-web-app/upstream/base/params.env"
 
 kustomize build $TEMP_DIR/kubeflow/example > $TEMP_DIR/$KUBEFLOW_MANIFEST
+mkdir -p $TEMP_DIR/$KUBEFLOW_DOCUMENTS_DIRECTORY
+( # Subshell to change directory.
+    cd $TEMP_DIR/$KUBEFLOW_DOCUMENTS_DIRECTORY
+    yq e '{"apiVersion": .apiVersion, "kind": .kind, "metadata": {"name": .metadata.name, "namespace": .metadata.namespace}}' $TEMP_DIR/$KUBEFLOW_MANIFEST -s '$index + "-" + .metadata.namespace + .metadata.name + ".yaml"'
+)
+
+delete_kubeflow() {
+    local delete_kubeflow_error=false
+    for kubeflow_document in $TEMP_DIR/$KUBEFLOW_DOCUMENTS_DIRECTORY/*.yaml; do
+        if [ -f "$kubeflow_document" ]; then
+            resource=$(yq e '{"apiVersion": .apiVersion, "kind": .kind, "metadata": {"name": .metadata.name, "namespace": .metadata.namespace}}' $kubeflow_document -o json)
+            resource_kind=$(echo $resource | jq -r '.kind')
+
+            # We check first to avoid complaints about missing CRDs (which may have already been removed).
+            # There is a race condition here which occurs if the resource_kind disappears immediately after the check.
+            if kubectl get $resource_kind --ignore-not-found && ! kubectl delete -f $kubeflow_document --ignore-not-found && kubectl get $resource_kind; then
+                log_bad "Error deleting resource: $resource"
+                delete_kubeflow_error=true
+            fi
+        fi
+    done
+    if $delete_kubeflow_error; then
+        return 1
+    fi
+}
 
 attempts=5
 log "Deleting all Kubeflow resources..."
 log "Attempts remaining: $((attempts))"
-while [ $attempts -gt 0 ] && ! kubectl delete --ignore-not-found -f $TEMP_DIR/$KUBEFLOW_MANIFEST; do
+while [ $attempts -gt 0 ] && ! delete_kubeflow; do
     attempts=$((attempts - 1))
     log "Kubeflow removal incomplete."
     log "Attempts remaining: $((attempts))"

--- a/kubeflow-teardown.sh
+++ b/kubeflow-teardown.sh
@@ -30,7 +30,6 @@ rm -rf install_kustomize.sh
 KUBEFLOW_VERSION='v1.9.0'
 KUBEFLOW_ISTIO_VERSION='1.22'
 KUBEFLOW_MANIFEST='kubeflow-manifest.yaml'
-KUBEFLOW_DOCUMENTS_DIRECTORY='kubeflow-documents'
 
 log "Cloning Kubeflow manifests..."
 git clone https://github.com/kubeflow/manifests.git $TEMP_DIR/kubeflow --branch $KUBEFLOW_VERSION


### PR DESCRIPTION
Tested on EC2 single-node cluster. It seems to work starting with a Kubeflow installation in a good state. Previously, profiles would have a remaining finalizer that caused uninstallation to hang. This has been addressed by deleting profiles before the operator that handles the finalizer.

Remaining issue: This does not work for a Kubeflow installation that is in a bad state (e.g. missing operators).

Reference: https://ibm.github.io/manifests/docs/deployment/uninstall
Assuming IBM didn't make too many modifications and Kubeflow did not change much from 1.8 to 1.9, this may be all we need to fix Kubeflow uninstallation.