### PR TITLE
deepops-setup.sh: add Docker Hub sign-in prompts

### DIFF
--- a/deepops-setup.sh
+++ b/deepops-setup.sh
@@ -7,6 +7,12 @@ source logging.sh
 YQ_BIN=yq_linux_amd64
 DOCKER_HUB_AUTH=""
 
+function jq_install() {
+  wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+  chmod +x jq
+  sudo cp jq /usr/local/bin/
+}
+
 function yq_install() {
   local yq_version=v4.44.1
   wget https://github.com/mikefarah/yq/releases/download/${yq_version}/${YQ_BIN}.tar.gz -O - | tar xz
@@ -149,6 +155,10 @@ function get_docker_hub_stats() {
 div
 
 log "Welcome to the MMC.AI Kubernetes setup helper!"
+
+div
+
+jq_install
 
 div
 

--- a/deepops-setup.sh
+++ b/deepops-setup.sh
@@ -107,6 +107,9 @@ EOF
 EOF
 }
 
+# See this StackOverflow response: https://stackoverflow.com/a/23243843
+# Used under CC BY-SA 3.0: https://creativecommons.org/licenses/by-sa/3.0/
+# Changes were made to the original response.
 function get_token() {
   output=""
   token=""

--- a/deepops-setup.sh
+++ b/deepops-setup.sh
@@ -107,32 +107,14 @@ EOF
 EOF
 }
 
-# See this StackOverflow response: https://stackoverflow.com/a/23243843
-# Used under CC BY-SA 3.0: https://creativecommons.org/licenses/by-sa/3.0/
-# Changes were made to the original response.
-function get_token() {
-  output=""
-  token=""
-  while IFS= read -p "$output" -r -s -n 1 c
-  do
-    if [[ $c == $'\0' ]]; then
-      break
-    fi
-
-    output="*"
-    token+="$c"
-  done
-  echo ""
-}
-
 function get_docker_hub_credentials() {
   log_good "Log into https://hub.docker.com/ and generate a \"Public Repo Read-Only\" token under Account Settings > Personal Access Token."
   log_good "Once generated, please copy it into the terminal. Press Enter to confirm your input:"
-  get_token
+  read -r -s docker_token
   log_good "Please also provide the Docker Hub username associated with this token:"
   read docker_username
   div
-  DOCKER_HUB_AUTH=$(echo -n '$docker_username:$token' | base64)
+  DOCKER_HUB_AUTH=$(echo -n '$docker_username:$docker_token' | base64)
 }
 
 function prompt_docker_hub_credentials() {

--- a/deepops-setup.sh
+++ b/deepops-setup.sh
@@ -4,15 +4,8 @@ curl -LfsSo logging.sh https://raw.githubusercontent.com/MemVerge/mmc.ai-setup/m
 
 source logging.sh
 
-## welcome message
-
-div
-log "Welcome to the MMC.AI DeepOps setup helper!"
-div
-
-## pull yq binary -- will need it to modify config settings later
-
 YQ_BIN=yq_linux_amd64
+DOCKER_HUB_AUTH=""
 
 function yq_install() {
   local yq_version=v4.44.1
@@ -44,9 +37,8 @@ if [ "$(basename "$PWD")" != "deepops" ]; then
   exit 1
 fi
 
-## add an unqualified registry
-
-cat << EOF > submodules/kubespray/roles/container-engine/cri-o/templates/unqualified.conf.j2
+function add_unqualified_registry() {
+  cat << EOF > submodules/kubespray/roles/container-engine/cri-o/templates/unqualified.conf.j2
 {%- set _unqualified_registries = ['docker.io'] -%}
 {% for _registry in crio_registries if _registry.unqualified -%}
 {% if _registry.prefix is defined -%}
@@ -58,6 +50,117 @@ cat << EOF > submodules/kubespray/roles/container-engine/cri-o/templates/unquali
 
 unqualified-search-registries = {{ _unqualified_registries | string }}
 EOF
+}
+
+function cat_docker_hub_credentials() {
+  if [ -z $DOCKER_HUB_AUTH ]; then
+    return 1
+  fi
+
+  log "Inserting the following block:"
+
+  cat << EOF
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "$DOCKER_HUB_AUTH"
+    }
+  }
+}
+EOF
+
+  log "Into ./submodules/kubespray/roles/container-engine/cri-o/templates/config.json.j2"
+
+  cat << EOF > submodules/kubespray/roles/container-engine/cri-o/templates/config.json.j2
+{% if crio_registry_auth is defined and crio_registry_auth|length %}
+{
+{% for reg in crio_registry_auth %}
+  "auths": {
+    "{{ reg.registry }}": {
+      "auth": "{{ (reg.username + ':' + reg.password) | string | b64encode }}"
+    }
+{% if not loop.last %}
+  },
+{% else %}
+  }
+{% endif %}
+{% endfor %}
+}
+{% else %}
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "$DOCKER_HUB_AUTH"
+    }
+  }
+}
+{% endif %}
+EOF
+}
+
+function get_docker_hub_credentials() {
+  log_good "Log into https://hub.docker.com/ and generate a \"Public Repo Read-Only\" token under Account Settings > Personal Access Token."
+  div
+  log_good "Please provide a Docker Hub username:"
+  read docker_username
+  log_good "Please provide a Docker Hub Personal Access Token:"
+  read -s docker_token
+
+  DOCKER_HUB_AUTH=$(echo -n '$docker_username:$docker_token' | base64)
+}
+
+function prompt_docker_hub_credentials() {
+  ## Ask the user for docker hub login credentials;
+  ## use these to construct a dockerconfigjson that can be fed to deepops
+  if [ -z $PULLS_REMAINING ]; then
+    return 1
+  fi
+
+  if [ $PULLS_REMAINING -lt "100" ]; then
+    log_bad "You have $PULLS_REMAINING Docker Hub container image pulls remaining."
+    log_bad "This is less than the default limit of 100 pulls for anonymous users."
+  else
+    log "You have at least 100 Docker Hub container image pulls remaining."
+    log "This meets the default limit for anonymous users."
+  fi
+
+  log "Kubernetes setup may fail partway if there are not sufficient image pull requests available."
+  log "Do you want to provide Docker Hub login credentials, so that you can increase your image pull limit to 200 or more? [y/N]"
+  read -p "" docker_response
+
+  case $docker_response in
+    [Yy]* )
+      div
+      get_docker_hub_credentials
+      return 0
+      ;;
+    * )
+      log "Continuing without Docker Hub credentials..."
+      return 0
+      ;;
+  esac
+}
+
+function get_docker_hub_stats() {
+  TOKEN="$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)"
+  PULLS_REMAINING="$(curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep -E -o "ratelimit-remaining: [0-9]+" | awk '{print $2}')"
+}
+
+div
+
+log "Welcome to the MMC.AI Kubernetes setup helper!"
+
+div
+
+cat_unqualified_registry
+
+div
+
+get_docker_hub_stats
+
+prompt_docker_hub_credentials
+
+cat_docker_hub_credentials
 
 ## modify relevant config values
 
@@ -91,7 +194,3 @@ div
 log_good "Attempting Kubernetes setup..."
 div
 ansible-playbook -l k8s-cluster playbooks/k8s-cluster.yml
-
-div
-log_good "Kubernetes setup was successful!"
-div


### PR DESCRIPTION
Per Scott's request. Ask the user to provide Docker Hub credentials to raise the image pull limit when doing deepops setup.

Asking him whether the merge is a good idea.

It's ok with Scott. Will merge.